### PR TITLE
[FEAT] 2주차 실습과제 구현

### DIFF
--- a/week2/seminar2/src/main/java/com/sopt/demo/common/ApiResponse.java
+++ b/week2/seminar2/src/main/java/com/sopt/demo/common/ApiResponse.java
@@ -1,0 +1,16 @@
+package com.sopt.demo.common;
+import lombok.*;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+
+    private final int code;
+    private final String message;
+    private T data;
+
+    public static <T> ApiResponse<T> success(SuccessType successType, T data) {
+        return new ApiResponse<T>(successType.getStatusCode(), successType.getMessage(), data);
+    }
+}

--- a/week2/seminar2/src/main/java/com/sopt/demo/common/SuccessType.java
+++ b/week2/seminar2/src/main/java/com/sopt/demo/common/SuccessType.java
@@ -1,0 +1,20 @@
+package com.sopt.demo.common;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum SuccessType {
+
+    GET_MEMBER_LIST_SUCCESS(HttpStatus.OK, "멤버 리스트 조회 성공");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getStatusCode() {
+        return this.httpStatus.value();
+    }
+}

--- a/week2/seminar2/src/main/java/com/sopt/demo/controller/MemberController.java
+++ b/week2/seminar2/src/main/java/com/sopt/demo/controller/MemberController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,5 +30,8 @@ public class MemberController {
         memberService.deleteMemberById(memberId);
         return ResponseEntity.noContent().build();
     }
-
+    @GetMapping("/all")
+    public ResponseEntity<List<MemberFindDto>> getAllMembers() {
+        return ResponseEntity.ok(memberService.findAllMembers());
+    }
 }

--- a/week2/seminar2/src/main/java/com/sopt/demo/controller/MemberController.java
+++ b/week2/seminar2/src/main/java/com/sopt/demo/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.sopt.demo.controller;
 
+import com.sopt.demo.common.ApiResponse;
 import com.sopt.demo.service.MemberQueryService;
 import com.sopt.demo.service.MemberCommandService;
 import com.sopt.demo.service.dto.MemberCreateDto;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
+import static com.sopt.demo.common.SuccessType.GET_MEMBER_LIST_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,7 +35,7 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
     @GetMapping("/all")
-    public ResponseEntity<List<MemberFindDto>> getAllMembers() {
-        return ResponseEntity.ok(memberQueryService.findAllMembers());
+    public ApiResponse<List<MemberFindDto>> getAllMembers() {
+        return ApiResponse.success(GET_MEMBER_LIST_SUCCESS,memberQueryService.findAllMembers());
     }
 }

--- a/week2/seminar2/src/main/java/com/sopt/demo/controller/MemberController.java
+++ b/week2/seminar2/src/main/java/com/sopt/demo/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.sopt.demo.controller;
 
 import com.sopt.demo.service.MemberQueryService;
-import com.sopt.demo.service.MemberService;
+import com.sopt.demo.service.MemberCommandService;
 import com.sopt.demo.service.dto.MemberCreateDto;
 import com.sopt.demo.service.dto.MemberFindDto;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +15,11 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/member")
 public class MemberController {
-    private final MemberService memberService;
+    private final MemberCommandService memberCommandService;
     private final MemberQueryService memberQueryService;
     @PostMapping
     public ResponseEntity createMember(@RequestBody MemberCreateDto memberCreate) {
-        return ResponseEntity.created(URI.create(memberService.createMember(memberCreate))).build();
+        return ResponseEntity.created(URI.create(memberCommandService.createMember(memberCreate))).build();
     }
 
     @GetMapping("/{memberId}")
@@ -29,7 +29,7 @@ public class MemberController {
     
     @DeleteMapping("/{memberId}")
     public ResponseEntity deleteMemberById(@PathVariable Long memberId){
-        memberService.deleteMemberById(memberId);
+        memberCommandService.deleteMemberById(memberId);
         return ResponseEntity.noContent().build();
     }
     @GetMapping("/all")

--- a/week2/seminar2/src/main/java/com/sopt/demo/controller/MemberController.java
+++ b/week2/seminar2/src/main/java/com/sopt/demo/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.sopt.demo.controller;
 
+import com.sopt.demo.service.MemberQueryService;
 import com.sopt.demo.service.MemberService;
 import com.sopt.demo.service.dto.MemberCreateDto;
 import com.sopt.demo.service.dto.MemberFindDto;
@@ -15,6 +16,7 @@ import java.util.List;
 @RequestMapping("/api/v1/member")
 public class MemberController {
     private final MemberService memberService;
+    private final MemberQueryService memberQueryService;
     @PostMapping
     public ResponseEntity createMember(@RequestBody MemberCreateDto memberCreate) {
         return ResponseEntity.created(URI.create(memberService.createMember(memberCreate))).build();
@@ -22,7 +24,7 @@ public class MemberController {
 
     @GetMapping("/{memberId}")
     public ResponseEntity<MemberFindDto> findMemberById(@PathVariable Long memberId){
-        return  ResponseEntity.ok(memberService.findMemberById(memberId));
+        return  ResponseEntity.ok(memberQueryService.findMemberById(memberId));
     }
     
     @DeleteMapping("/{memberId}")
@@ -32,6 +34,6 @@ public class MemberController {
     }
     @GetMapping("/all")
     public ResponseEntity<List<MemberFindDto>> getAllMembers() {
-        return ResponseEntity.ok(memberService.findAllMembers());
+        return ResponseEntity.ok(memberQueryService.findAllMembers());
     }
 }

--- a/week2/seminar2/src/main/java/com/sopt/demo/service/MemberCommandService.java
+++ b/week2/seminar2/src/main/java/com/sopt/demo/service/MemberCommandService.java
@@ -3,20 +3,16 @@ package com.sopt.demo.service;
 import com.sopt.demo.domain.Member;
 import com.sopt.demo.respository.MemberRepository;
 import com.sopt.demo.service.dto.MemberCreateDto;
-import com.sopt.demo.service.dto.MemberFindDto;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class MemberService {
+public class MemberCommandService {
 
     private final MemberRepository memberRepository;
 

--- a/week2/seminar2/src/main/java/com/sopt/demo/service/MemberQueryService.java
+++ b/week2/seminar2/src/main/java/com/sopt/demo/service/MemberQueryService.java
@@ -1,0 +1,32 @@
+package com.sopt.demo.service;
+
+import com.sopt.demo.domain.Member;
+import com.sopt.demo.respository.MemberRepository;
+import com.sopt.demo.service.dto.MemberFindDto;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberQueryService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberFindDto findMemberById(Long memberId) {
+        return MemberFindDto.of(memberRepository.findById(memberId).orElseThrow(
+                () -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다.")
+        ));
+    }
+
+    public List<MemberFindDto> findAllMembers() {
+        List<Member> memberList = memberRepository.findAll();
+        return memberList.stream().map(MemberFindDto::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/week2/seminar2/src/main/java/com/sopt/demo/service/MemberService.java
+++ b/week2/seminar2/src/main/java/com/sopt/demo/service/MemberService.java
@@ -15,11 +15,11 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    @Transactional
     public String createMember(
             MemberCreateDto memberCreateDto
     ) {
@@ -28,23 +28,9 @@ public class MemberService {
         return member.getId().toString();
     }
 
-    public MemberFindDto findMemberById(Long memberId) {
-        return MemberFindDto.of(memberRepository.findById(memberId).orElseThrow(
-                () -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다.")
-        ));
-    }
-
-    @Transactional
     public void deleteMemberById(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다."));
         memberRepository.delete(member);
-    }
-
-    @Transactional
-    public List<MemberFindDto> findAllMembers() {
-        List<Member> memberList = memberRepository.findAll();
-        return memberList.stream().map(MemberFindDto::of)
-                .collect(Collectors.toList());
     }
 }

--- a/week2/seminar2/src/main/java/com/sopt/demo/service/MemberService.java
+++ b/week2/seminar2/src/main/java/com/sopt/demo/service/MemberService.java
@@ -9,6 +9,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 
 @Service
 @RequiredArgsConstructor
@@ -36,5 +39,12 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다."));
         memberRepository.delete(member);
+    }
+
+    @Transactional
+    public List<MemberFindDto> findAllMembers() {
+        List<Member> memberList = memberRepository.findAll();
+        return memberList.stream().map(MemberFindDto::of)
+                .collect(Collectors.toList());
     }
 }

--- a/week2/seminar2/src/test/java/com/sopt/demo/settirngs/controller/MemberControllerTest.java
+++ b/week2/seminar2/src/test/java/com/sopt/demo/settirngs/controller/MemberControllerTest.java
@@ -2,7 +2,7 @@ package com.sopt.demo.settirngs.controller;
 
 import com.sopt.demo.service.dto.MemberCreateDto;
 import com.sopt.demo.respository.MemberRepository;
-import com.sopt.demo.service.MemberService;
+import com.sopt.demo.service.MemberCommandService;
 import com.sopt.demo.settirngs.settirngs.ApiTest;
 import io.restassured.RestAssured;
 import org.assertj.core.api.Assertions;
@@ -19,7 +19,7 @@ import static com.sopt.demo.domain.Part.SERVER;
 public class MemberControllerTest extends ApiTest {
 
     @Autowired
-    private MemberService memberService;
+    private MemberCommandService memberCommandService;
 
     @Autowired
     private MemberRepository memberRepository;


### PR DESCRIPTION
- closes #5 
## 📣 이 주의 과제
<!-- 이번 주에 구현한 API가 포함되어 있는 뷰와 API에 대한 설명을 적어주세요 -->
- [x] 세미나 때 작성한 api를 포함한 [명세서](https://fancy-death-29b.notion.site/API-0646a97657654b188d6fdd21a42075e4?pvs=4) 작성
   **2차과제** 보드 확인해주세요! + 명세서안에 postman 캡쳐 제출했습니다
- [x] 멤버 리스트를 반환하는 api 구현

---
## 📝요구사항 분석
<!-- 해당 API에 대한 요구사항(사용자 플로우)을/를 설명해주세요 -->
- 등록된 멤버를 모두 반환해주는 api를 구현했습니다.
- 응답 Response를 바로 확인하기 위해 ApiResponse를 구현했습니다.
- 성공메세지를 커스텀해서 enum으로 구현했습니다.
- MemberCommandService와 MemberQueryService를 분리했습니다.

---
## ️🤹‍♀️구현 고민 사항
<!-- 구현하면서 고민/트러블 슈팅했던 부분을 적어주세요 -->
api 요청 후 postman에 내용이 안보여서 db를 확인해야하는 불편함이 있어서 ApiResponse를 구현했습니다. 
~~ApiResponse구현하는 방법 정리해서 아티클 작성해보겠습니다..!! 이번주안에 꼬옥!!!~~
하려고했는데 이미 상준이가 해놨습니다 여러분 >>[클릭](https://www.notion.so/sopt-official/SERVER-7954459be00d42939190fee1ecd99b66?p=a238176af7be4cf3bad575b8b369055d&pm=s)<<
---
## 🙋‍♀질문있어요!
<!-- 구현하면서 코드리뷰조원이나 명예 OB 분들께 하고 싶었던 질문이 있다면 (필요시)코드 좌표와 함께 **자세히** 적어주세요! --> 전체 조회하는 url에 대해 '-s' vs 'list' vs 'all' 어떤게 젤 좋을까요 헤헤 원하는거 쓰면 될까요
https://github.com/NOW-SOPT-SERVER/bo-ram-bo-ram/blob/5264967655b798ec48290973bcd9ba7bd529ca24/week2/seminar2/src/main/java/com/sopt/demo/controller/MemberController.java#L37-L40

