### PR TITLE
[FEAT] 3주차 실습과제 구현

### DIFF
--- a/week3/src/main/java/com/sopt/seminar/common/dto/ApiResponse.java
+++ b/week3/src/main/java/com/sopt/seminar/common/dto/ApiResponse.java
@@ -1,0 +1,17 @@
+package com.sopt.seminar.common.dto;
+
+import lombok.*;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+
+    private final int code;
+    private final String message;
+    private T data;
+
+    public static <T> ApiResponse<T> success(SuccessMessage successType, T data) {
+        return new ApiResponse<T>(successType.getStatus(),successType.getMessage(), data);
+    }
+}

--- a/week3/src/main/java/com/sopt/seminar/common/dto/ErrorMessage.java
+++ b/week3/src/main/java/com/sopt/seminar/common/dto/ErrorMessage.java
@@ -8,8 +8,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorMessage {
 
+    //404
     MEMBER_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
     BLOG_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 블로그가 존재하지 않습니다."),
+
+    //400
+    POSTING_TITLE_LONG(HttpStatus.BAD_REQUEST.value(), "블로그 제목이 너무 깁니다."),
+    POSTING_CONTENT_LONG(HttpStatus.BAD_REQUEST.value(), "블로그 내용이 너무 깁니다."),
     ;
     private final int status;
     private final String message;

--- a/week3/src/main/java/com/sopt/seminar/common/dto/SuccessMessage.java
+++ b/week3/src/main/java/com/sopt/seminar/common/dto/SuccessMessage.java
@@ -8,8 +8,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessMessage {
 
-    BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성이 완료되었습니다."),
-    POSTING_CREATE_SUCCESS(HttpStatus.CREATED.value(),"글 작성 성공")
+    BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성 성공"),
+    POSTING_CREATE_SUCCESS(HttpStatus.CREATED.value(),"글 작성 성공"),
+    GET_ALL_POSTINGS_SUCCESS(HttpStatus.OK.value(), "게시글 리스트 조회 성공")
     ;
     private final int status;
     private final String message;

--- a/week3/src/main/java/com/sopt/seminar/common/dto/SuccessMessage.java
+++ b/week3/src/main/java/com/sopt/seminar/common/dto/SuccessMessage.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum SuccessMessage {
 
     BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성이 완료되었습니다."),
+    POSTING_CREATE_SUCCESS(HttpStatus.CREATED.value(),"글 작성 성공")
     ;
     private final int status;
     private final String message;

--- a/week3/src/main/java/com/sopt/seminar/controller/BlogController.java
+++ b/week3/src/main/java/com/sopt/seminar/controller/BlogController.java
@@ -22,8 +22,8 @@ public class BlogController {
     @PostMapping("/blog")
     public ResponseEntity<SuccessStatusResponse> createBlog(
             @RequestHeader(name = "memberId") Long memberId,
-            @RequestBody BlogCreateRequest blogCreateRequest) {
-        return ResponseEntity.status(HttpStatus.CREATED).header(
+            @RequestBody BlogCreateRequest blogCreateRequest
+    ) { return ResponseEntity.status(HttpStatus.CREATED).header(
                         "Location",
                         blogService.create(memberId, blogCreateRequest))
                 .body(SuccessStatusResponse.of(SuccessMessage.BLOG_CREATE_SUCCESS));

--- a/week3/src/main/java/com/sopt/seminar/controller/MemberController.java
+++ b/week3/src/main/java/com/sopt/seminar/controller/MemberController.java
@@ -13,6 +13,7 @@ import java.net.URI;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/member")
 public class MemberController {
+
     private final MemberService memberService;
     @PostMapping
     public ResponseEntity createMember(@RequestBody MemberCreateDto memberCreate) {

--- a/week3/src/main/java/com/sopt/seminar/controller/PostingController.java
+++ b/week3/src/main/java/com/sopt/seminar/controller/PostingController.java
@@ -1,0 +1,28 @@
+package com.sopt.seminar.controller;
+
+import com.sopt.seminar.common.dto.SuccessMessage;
+import com.sopt.seminar.common.dto.SuccessStatusResponse;
+import com.sopt.seminar.service.PostingService;
+import com.sopt.seminar.service.dto.PostingCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("api/v1/posting")
+@RequiredArgsConstructor
+public class PostingController {
+
+    private final PostingService postingService;
+
+    @PostMapping
+    public ResponseEntity<SuccessStatusResponse> createPosting(
+            @RequestHeader(name = "memberId")  Long memberId,
+            @RequestBody PostingCreateRequest postingCreateRequest
+    ){        return ResponseEntity.status(HttpStatus.CREATED)
+            .header("postingId", postingService.createPosting(memberId, postingCreateRequest))
+            .body(SuccessStatusResponse.of(SuccessMessage.POSTING_CREATE_SUCCESS));
+
+    }
+}

--- a/week3/src/main/java/com/sopt/seminar/controller/PostingController.java
+++ b/week3/src/main/java/com/sopt/seminar/controller/PostingController.java
@@ -1,14 +1,20 @@
 package com.sopt.seminar.controller;
 
+import com.sopt.seminar.common.dto.ApiResponse;
 import com.sopt.seminar.common.dto.SuccessMessage;
 import com.sopt.seminar.common.dto.SuccessStatusResponse;
 import com.sopt.seminar.service.PostingService;
 import com.sopt.seminar.service.dto.PostingCreateRequest;
+import com.sopt.seminar.service.dto.PostingGetAllDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.sopt.seminar.common.dto.SuccessMessage.GET_ALL_POSTINGS_SUCCESS;
 
 @RestController
 @RequestMapping("api/v1/posting")
@@ -24,6 +30,11 @@ public class PostingController {
     ){        return ResponseEntity.status(HttpStatus.CREATED)
             .header("postingId", postingService.createPosting(memberId, postingCreateRequest))
             .body(SuccessStatusResponse.of(SuccessMessage.POSTING_CREATE_SUCCESS));
-
     }
+
+    @GetMapping("/all")
+    public ApiResponse<List<PostingGetAllDto>> getAllPostings() {
+        return ApiResponse.success(GET_ALL_POSTINGS_SUCCESS, postingService.getAllPostings());
+    }
+
 }

--- a/week3/src/main/java/com/sopt/seminar/controller/PostingController.java
+++ b/week3/src/main/java/com/sopt/seminar/controller/PostingController.java
@@ -4,6 +4,7 @@ import com.sopt.seminar.common.dto.SuccessMessage;
 import com.sopt.seminar.common.dto.SuccessStatusResponse;
 import com.sopt.seminar.service.PostingService;
 import com.sopt.seminar.service.dto.PostingCreateRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,7 @@ public class PostingController {
     @PostMapping
     public ResponseEntity<SuccessStatusResponse> createPosting(
             @RequestHeader(name = "memberId")  Long memberId,
-            @RequestBody PostingCreateRequest postingCreateRequest
+            @Valid @RequestBody PostingCreateRequest postingCreateRequest
     ){        return ResponseEntity.status(HttpStatus.CREATED)
             .header("postingId", postingService.createPosting(memberId, postingCreateRequest))
             .body(SuccessStatusResponse.of(SuccessMessage.POSTING_CREATE_SUCCESS));

--- a/week3/src/main/java/com/sopt/seminar/domain/Posting.java
+++ b/week3/src/main/java/com/sopt/seminar/domain/Posting.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Post extends BaseTimeEntity{
+public class Posting extends BaseTimeEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/week3/src/main/java/com/sopt/seminar/domain/Posting.java
+++ b/week3/src/main/java/com/sopt/seminar/domain/Posting.java
@@ -1,6 +1,7 @@
 package com.sopt.seminar.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,4 +20,20 @@ public class Posting extends BaseTimeEntity{
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Blog blog;
+
+    @Builder
+    private Posting(final Blog blog, final String title, final String content) {
+        this.blog = blog;
+        this.title = title;
+        this.content = content;
+    }
+
+    public static Posting createPosting(final Blog blog, final String title, final String content) {
+        return Posting.builder()
+                .blog(blog)
+                .title(title)
+                .content(content)
+                .build();
+    }
+
 }

--- a/week3/src/main/java/com/sopt/seminar/respository/PostingRepository.java
+++ b/week3/src/main/java/com/sopt/seminar/respository/PostingRepository.java
@@ -1,0 +1,7 @@
+package com.sopt.seminar.respository;
+
+import com.sopt.seminar.domain.Posting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostingRepository extends JpaRepository<Posting, Long> {
+}

--- a/week3/src/main/java/com/sopt/seminar/service/PostingService.java
+++ b/week3/src/main/java/com/sopt/seminar/service/PostingService.java
@@ -1,0 +1,32 @@
+package com.sopt.seminar.service;
+
+import com.sopt.seminar.common.dto.ErrorMessage;
+import com.sopt.seminar.domain.Blog;
+import com.sopt.seminar.domain.Posting;
+import com.sopt.seminar.exception.NotFoundException;
+import com.sopt.seminar.respository.BlogRepository;
+import com.sopt.seminar.respository.MemberRepository;
+import com.sopt.seminar.respository.PostingRepository;
+import com.sopt.seminar.service.dto.PostingCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostingService {
+    private final PostingRepository postingRepository;
+    private final BlogRepository blogRepository;
+    private final MemberRepository memberRepository;
+
+    public String createPosting(Long memberId, PostingCreateRequest requestDto) {
+        memberRepository.findById(memberId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND_BY_ID_EXCEPTION));
+
+        Blog blog = blogRepository.findById(memberId).orElseThrow(
+                ()->new NotFoundException(ErrorMessage.BLOG_NOT_FOUND_BY_ID_EXCEPTION));
+
+        Posting posting = postingRepository.save(Posting.createPosting(blog, requestDto.title(),requestDto.content()));
+        postingRepository.save(posting);
+        return posting.toString();
+    }
+}

--- a/week3/src/main/java/com/sopt/seminar/service/PostingService.java
+++ b/week3/src/main/java/com/sopt/seminar/service/PostingService.java
@@ -8,8 +8,12 @@ import com.sopt.seminar.respository.BlogRepository;
 import com.sopt.seminar.respository.MemberRepository;
 import com.sopt.seminar.respository.PostingRepository;
 import com.sopt.seminar.service.dto.PostingCreateRequest;
+import com.sopt.seminar.service.dto.PostingGetAllDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,5 +32,11 @@ public class PostingService {
         Posting posting = postingRepository.save(Posting.createPosting(blog, requestDto.title(),requestDto.content()));
         postingRepository.save(posting);
         return posting.toString();
+    }
+
+    public List<PostingGetAllDto> getAllPostings(){
+        List<Posting> postingList = postingRepository.findAll();
+        return postingList.stream().map(PostingGetAllDto::of)
+                .collect(Collectors.toList());
     }
 }

--- a/week3/src/main/java/com/sopt/seminar/service/dto/PostingCreateRequest.java
+++ b/week3/src/main/java/com/sopt/seminar/service/dto/PostingCreateRequest.java
@@ -1,7 +1,13 @@
 package com.sopt.seminar.service.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record PostingCreateRequest (
-        String title,
-        String content
+        @Size(max=20,message = "블로그 제목이 너무 깁니다.")
+        @NotBlank String title,
+
+        @Size(max=500,message = "블로그 내용이 너무 깁니다.")
+        @NotBlank String content
 ) {
 }

--- a/week3/src/main/java/com/sopt/seminar/service/dto/PostingCreateRequest.java
+++ b/week3/src/main/java/com/sopt/seminar/service/dto/PostingCreateRequest.java
@@ -1,0 +1,7 @@
+package com.sopt.seminar.service.dto;
+
+public record PostingCreateRequest (
+        String title,
+        String content
+) {
+}

--- a/week3/src/main/java/com/sopt/seminar/service/dto/PostingGetAllDto.java
+++ b/week3/src/main/java/com/sopt/seminar/service/dto/PostingGetAllDto.java
@@ -1,0 +1,14 @@
+package com.sopt.seminar.service.dto;
+
+import com.sopt.seminar.domain.Posting;
+
+public record PostingGetAllDto (
+        String title,
+        String content
+){
+    public static PostingGetAllDto of(
+            Posting posting
+    ){
+        return new PostingGetAllDto(posting.getTitle(), posting.getContent());
+    }
+}

--- a/week3/src/main/resources/application.yml
+++ b/week3/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:tcp://localhost/~/test
+    username: sa
+    password: 1234
+#spring:
+#  datasource:
+#    driver-class-name: org.postgresql.Driver
+#    url: jdbc:postgresql://localhost:5432/seminar3
+#    username: sa
+#    password: 1234
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true

--- a/week3/src/test/java/com/sopt/seminar/DemoApplicationTests.java
+++ b/week3/src/test/java/com/sopt/seminar/DemoApplicationTests.java
@@ -1,0 +1,13 @@
+package com.sopt.seminar;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemoApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/week3/src/test/java/com/sopt/seminar/settirngs/controller/BlogControllerTest.java
+++ b/week3/src/test/java/com/sopt/seminar/settirngs/controller/BlogControllerTest.java
@@ -1,0 +1,64 @@
+package com.sopt.seminar.settirngs.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.seminar.service.dto.BlogCreateRequest;
+import com.sopt.seminar.controller.BlogController;
+import com.sopt.seminar.respository.BlogRepository;
+import com.sopt.seminar.respository.MemberRepository;
+import com.sopt.seminar.service.BlogService;
+import com.sopt.seminar.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BlogController.class)
+@AutoConfigureMockMvc
+public class BlogControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @SpyBean
+    private BlogService blogService;
+
+    @SpyBean
+    private MemberService memberService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private BlogRepository blogRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper; //생성하는 객체를 String JSON 배열로 바꾸기 위해 사용
+
+    @Nested
+    class createBlog {
+        @Test
+        @DisplayName("Blog 생성 실패 테스트")
+        public void createBlogSFail() throws Exception {
+            //given
+            String request = objectMapper.writeValueAsString(new BlogCreateRequest("보람이네 블로그", "블로그입니다."));
+
+            //when
+            mockMvc.perform(
+                            post("/api/v1/blog")
+                                    .content(request).
+                                    header("memberId", 2)
+                                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound()) //생성 실패 시나리오로 NotFound가 돌아오는 상황을 테스트
+                    .andDo(print()); // 끝난 후 모든 결과를 출력
+
+        }
+    }
+}

--- a/week3/src/test/java/com/sopt/seminar/settirngs/controller/MemberControllerTest.java
+++ b/week3/src/test/java/com/sopt/seminar/settirngs/controller/MemberControllerTest.java
@@ -1,0 +1,54 @@
+package com.sopt.seminar.settirngs.controller;
+
+import com.sopt.seminar.service.dto.MemberCreateDto;
+import com.sopt.seminar.respository.MemberRepository;
+import com.sopt.seminar.service.MemberService;
+import com.sopt.seminar.settirngs.settirngs.ApiTest;
+import io.restassured.RestAssured;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static com.sopt.seminar.domain.Part.SERVER;
+
+
+public class MemberControllerTest extends ApiTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Nested // 중첩 테스트를 진행할 수 있게하는 테스트
+    @DisplayName("멤버 생성 테스트")
+    public class CreateMember {
+
+        @Test
+        @DisplayName("요청 성공 케이스")
+        public void createMemberSuccess() throws Exception {
+            //given
+            final var request = new MemberCreateDto(
+                    "도소현",
+                    SERVER,
+                    24);
+            //when
+            final var response = RestAssured
+                    .given()
+                    .log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .when()
+                    .post("/api/v1/member")
+                    .then().log().all().extract();
+            //then
+            Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        }
+
+    }
+
+}

--- a/week3/src/test/java/com/sopt/seminar/settirngs/settirngs/ApiTest.java
+++ b/week3/src/test/java/com/sopt/seminar/settirngs/settirngs/ApiTest.java
@@ -1,0 +1,19 @@
+package com.sopt.seminar.settirngs.settirngs;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+        //각 테스트 진행 전 실행
+    void setUp() {
+        RestAssured.port = port;
+    }
+}


### PR DESCRIPTION
- closes #12 
## 📣 이 주의 과제
<!-- 이번 주에 구현한 API가 포함되어 있는 뷰와 API에 대한 설명을 적어주세요 -->
- 블로그에 대해 글을 작성하는 [POST API](https://www.notion.so/API-0646a97657654b188d6fdd21a42075e4?p=ce63117bd32f429db2d4d7130927ffd2&pm=s&pvs=31) 구현
- [GET API](https://www.notion.so/API-0646a97657654b188d6fdd21a42075e4?p=09e1aac387de4aa09bf5cdc286d79aa3&pm=s) 구현
- POST 되는 객체에 대해 Request Body Validation진행
- GET API 에서 SuccessStatusResponse와 ErrorResponse를 변경해서 Data를 담아보낼 수 있도록 수정
- 블로그를 소유하지 않은 사용자가 해당 블로그에 글을 작성할 경우 발생할 예외처리 진행

---
## ️🤹‍♀️구현 고민 사항
<!-- 구현하면서 고민/트러블 슈팅했던 부분을 적어주세요 -->
responseEntity로 응답을 만들어내는 방법과 apiResponse로 응답을 만들어내는 방법 중에 고민이 됐었습니다!
조금 더 생각 정리를 해봐야할 것 같아요.

---
## 🙋‍♀질문있어요!
<!-- 구현하면서 코드리뷰조원이나 명예 OB 분들께 하고 싶었던 질문이 있다면 (필요시)코드 좌표와 함께 **자세히** 적어주세요! -->
responseEntity와 apiResponse중에 어떤 방식이 더 옳다고 생각하시나요?
컨트롤러단에서의 가독성과 실제 응답의 상태코드 말고도 다른 응답이 가능하다는 장점을 생각하면 apiResponse가 옳다고 생각됩니다만 어쨌든 apiResponse는 ResponseEntity 사이에 한 번의 추가적인 레이어가 존재한다는 단점이 있다고 생각됩니다!! 조금 더 고민해보겠습니다~~

